### PR TITLE
Fix non-thread-safe variable

### DIFF
--- a/src/libcsc/csc_coder.cpp
+++ b/src/libcsc/csc_coder.cpp
@@ -85,7 +85,7 @@ void Coder::EncDirect16(uint32_t val,uint32_t len)
 
 void Coder::RC_ShiftLow(void)
 {
-    static uint8_t temp;
+    uint8_t temp;
     if ((uint32_t)rc_low_ < (uint32_t)0xFF000000 || (int32_t)(rc_low_ >> 32) != 0)
     {
         temp = rc_cache_;


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=5865)
  Write of size 1 at 0x7fc8fb6ff5a0 by thread T9 (mutexes: write M17):
    #0 Coder::RC_ShiftLow() /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_coder.cpp:91 (libsquash0.5-plugin-csc.so+0x0000000046c3)
    #1 Model::EncodeLiteral(unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_model.cpp:179 (libsquash0.5-plugin-csc.so+0x00000001ac15)
    #2 LZ::compress_normal(unsigned int, bool) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_lz.cpp:165 (libsquash0.5-plugin-csc.so+0x0000000109f7)
    #3 LZ::EncodeNormal(unsigned char*, unsigned int, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_lz.cpp:70 (libsquash0.5-plugin-csc.so+0x0000000101e7)
    #4 CSCEncoder::compress_block(unsigned char*, unsigned int, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_encoder_main.cpp:54 (libsquash0.5-plugin-csc.so+0x00000000d885)
    #5 CSCEncoder::Compress(unsigned char*, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_encoder_main.cpp:141 (libsquash0.5-plugin-csc.so+0x00000000dda5)
    #6 CSCEnc_Encode /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_enc.cpp:169 (libsquash0.5-plugin-csc.so+0x00000000d2cc)
    #7 squash_csc_process_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:327 (libsquash0.5-plugin-csc.so+0x0000000026ef)
    #8 squash_stream_thread_func /home/nemequ/local/src/squash/squash/stream.c:167 (libsquash0.5.so+0x000000026348)
    #9 _thrd_wrapper_function /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:561 (libsquash0.5.so+0x000000027a0a)
    #10 <null> <null> (libtsan.so.0+0x0000000235b9)

  Previous write of size 1 at 0x7fc8fb6ff5a0 by thread T11 (mutexes: write M19):
    #0 Coder::RC_ShiftLow() /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_coder.cpp:91 (libsquash0.5-plugin-csc.so+0x0000000046c3)
    #1 Model::EncodeLiteral(unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_model.cpp:179 (libsquash0.5-plugin-csc.so+0x00000001ac15)
    #2 LZ::compress_normal(unsigned int, bool) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_lz.cpp:165 (libsquash0.5-plugin-csc.so+0x0000000109f7)
    #3 LZ::EncodeNormal(unsigned char*, unsigned int, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_lz.cpp:70 (libsquash0.5-plugin-csc.so+0x0000000101e7)
    #4 CSCEncoder::compress_block(unsigned char*, unsigned int, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_encoder_main.cpp:54 (libsquash0.5-plugin-csc.so+0x00000000d885)
    #5 CSCEncoder::Compress(unsigned char*, unsigned int) /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_encoder_main.cpp:141 (libsquash0.5-plugin-csc.so+0x00000000dda5)
    #6 CSCEnc_Encode /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_enc.cpp:169 (libsquash0.5-plugin-csc.so+0x00000000d2cc)
    #7 squash_csc_process_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:327 (libsquash0.5-plugin-csc.so+0x0000000026ef)
    #8 squash_stream_thread_func /home/nemequ/local/src/squash/squash/stream.c:167 (libsquash0.5.so+0x000000026348)
    #9 _thrd_wrapper_function /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:561 (libsquash0.5.so+0x000000027a0a)
    #10 <null> <null> (libtsan.so.0+0x0000000235b9)

  Location is global 'Coder::RC_ShiftLow()::temp' of size 1 at 0x7fc8fb6ff5a0 (libsquash0.5-plugin-csc.so+0x0000002235a0)

  Mutex M17 (0x7d2c00005760) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x0000000285a5)
    #1 mtx_init /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:83 (libsquash0.5.so+0x0000000276ad)
    #2 squash_stream_init /home/nemequ/local/src/squash/squash/stream.c:275 (libsquash0.5.so+0x000000026866)
    #3 squash_csc_stream_init /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:251 (libsquash0.5-plugin-csc.so+0x000000002193)
    #4 squash_csc_stream_new /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:266 (libsquash0.5-plugin-csc.so+0x000000002256)
    #5 squash_csc_create_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:295 (libsquash0.5-plugin-csc.so+0x0000000023f3)
    #6 squash_codec_create_stream_with_options /home/nemequ/local/src/squash/squash/codec.c:495 (libsquash0.5.so+0x00000000ba21)
    #7 squash_codec_compress_with_options /home/nemequ/local/src/squash/squash/codec.c:612 (libsquash0.5.so+0x00000000bf72)
    #8 compress_buffer_thread_func /home/nemequ/local/src/squash/tests/threads.c:16 (threads+0x000000001d32)
    #9 <null> <null> (libglib-2.0.so.0+0x000000071334)

  Mutex M19 (0x7d2c0002bf60) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x0000000285a5)
    #1 mtx_init /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:83 (libsquash0.5.so+0x0000000276ad)
    #2 squash_stream_init /home/nemequ/local/src/squash/squash/stream.c:275 (libsquash0.5.so+0x000000026866)
    #3 squash_csc_stream_init /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:251 (libsquash0.5-plugin-csc.so+0x000000002193)
    #4 squash_csc_stream_new /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:266 (libsquash0.5-plugin-csc.so+0x000000002256)
    #5 squash_csc_create_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:295 (libsquash0.5-plugin-csc.so+0x0000000023f3)
    #6 squash_codec_create_stream_with_options /home/nemequ/local/src/squash/squash/codec.c:495 (libsquash0.5.so+0x00000000ba21)
    #7 squash_codec_compress_with_options /home/nemequ/local/src/squash/squash/codec.c:612 (libsquash0.5.so+0x00000000bf72)
    #8 compress_buffer_thread_func /home/nemequ/local/src/squash/tests/threads.c:16 (threads+0x000000001d32)
    #9 <null> <null> (libglib-2.0.so.0+0x000000071334)

  Thread T9 (tid=5875, running) created by thread T5 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027a67)
    #1 thrd_create /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:596 (libsquash0.5.so+0x000000027adc)
    #2 squash_stream_init /home/nemequ/local/src/squash/squash/stream.c:286 (libsquash0.5.so+0x000000026981)
    #3 squash_csc_stream_init /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:251 (libsquash0.5-plugin-csc.so+0x000000002193)
    #4 squash_csc_stream_new /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:266 (libsquash0.5-plugin-csc.so+0x000000002256)
    #5 squash_csc_create_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:295 (libsquash0.5-plugin-csc.so+0x0000000023f3)
    #6 squash_codec_create_stream_with_options /home/nemequ/local/src/squash/squash/codec.c:495 (libsquash0.5.so+0x00000000ba21)
    #7 squash_codec_compress_with_options /home/nemequ/local/src/squash/squash/codec.c:612 (libsquash0.5.so+0x00000000bf72)
    #8 compress_buffer_thread_func /home/nemequ/local/src/squash/tests/threads.c:16 (threads+0x000000001d32)
    #9 <null> <null> (libglib-2.0.so.0+0x000000071334)

  Thread T11 (tid=5877, finished) created by thread T7 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027a67)
    #1 thrd_create /home/nemequ/local/src/squash/squash/tinycthread/source/tinycthread.c:596 (libsquash0.5.so+0x000000027adc)
    #2 squash_stream_init /home/nemequ/local/src/squash/squash/stream.c:286 (libsquash0.5.so+0x000000026981)
    #3 squash_csc_stream_init /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:251 (libsquash0.5-plugin-csc.so+0x000000002193)
    #4 squash_csc_stream_new /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:266 (libsquash0.5-plugin-csc.so+0x000000002256)
    #5 squash_csc_create_stream /home/nemequ/local/src/squash/plugins/csc/squash-csc.cpp:295 (libsquash0.5-plugin-csc.so+0x0000000023f3)
    #6 squash_codec_create_stream_with_options /home/nemequ/local/src/squash/squash/codec.c:495 (libsquash0.5.so+0x00000000ba21)
    #7 squash_codec_compress_with_options /home/nemequ/local/src/squash/squash/codec.c:612 (libsquash0.5.so+0x00000000bf72)
    #8 compress_buffer_thread_func /home/nemequ/local/src/squash/tests/threads.c:16 (threads+0x000000001d32)
    #9 <null> <null> (libglib-2.0.so.0+0x000000071334)

SUMMARY: ThreadSanitizer: data race /home/nemequ/local/src/squash/plugins/csc/csc/src/libcsc/csc_coder.cpp:91 Coder::RC_ShiftLow()
==================
```
